### PR TITLE
 Make enumerators compatible with Dart 1 and Dart 2

### DIFF
--- a/benchmark/random_access.dart
+++ b/benchmark/random_access.dart
@@ -3,8 +3,8 @@
 
 // Author: Paul Brauner (polux@google.com)
 
-import 'dart:math';
 import 'package:benchmark_harness/benchmark_harness.dart';
+import 'package:dart2_constant/math.dart' as polyfill_math;
 import 'package:enumerators/combinators.dart' as c;
 
 class IterationBenchmark extends BenchmarkBase {
@@ -18,7 +18,7 @@ class IterationBenchmark extends BenchmarkBase {
 
   void run() {
     for (final part in listsOfNats.parts.skip(500).take(20)) {
-      part[part.length ~/ PI];
+      part[part.length ~/ polyfill_math.pi];
     }
   }
 }

--- a/lib/combinators.dart
+++ b/lib/combinators.dart
@@ -127,7 +127,7 @@ Enumeration<int> _mkInts() {
 }
 
 Enumeration<Rational> _mkRationals() {
-  return singleton(new Rational(0)) +
+  return singleton(new Rational(BigInt.from(0))) +
       (positiveRationals + positiveRationals.map((r) => -r)).pay();
 }
 
@@ -140,7 +140,7 @@ Rational _unGcd(List<bool> path) {
     else
       numerator += denominator;
   }
-  return new Rational(numerator, denominator);
+  return new Rational(BigInt.from(numerator), BigInt.from(denominator));
 }
 
 Enumeration<Rational> _mkPositiveRationals() {

--- a/lib/src/enumeration.dart
+++ b/lib/src/enumeration.dart
@@ -40,7 +40,7 @@ class Enumeration<A> extends IterableBase<A> {
       new Thunk(() => new LazyList.singleton(new Finite.singleton(x))));
 
   factory Enumeration.fix(Enumeration<A> f(Enumeration<A> e)) {
-    final enumeration = new Enumeration(null);
+    final enumeration = new Enumeration<A>(null);
     final result = f(enumeration);
     enumeration.thunk = result.thunk;
     return result;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,8 @@ environment:
   sdk: '>=1.21.0 <2.0.0'
 documentation: http://goo.gl/UZX3qD
 dependencies:
+  dart2_constant: ^1.0.1
   rational: '>=0.0.4 <1.0.0'
 dev_dependencies:
   benchmark_harness: '>=1.0.2 <2.0.0'
-  test: '>=0.9.0 <1.0.0'
+  test: '>=0.9.0 <1.3.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,4 +10,4 @@ dependencies:
   rational: '>=0.0.4 <1.0.0'
 dev_dependencies:
   benchmark_harness: '>=1.0.2 <2.0.0'
-  unittest: '>=0.9.0 <0.12.0'
+  test: '>=0.9.0 <1.0.0'

--- a/test/combinators_test.dart
+++ b/test/combinators_test.dart
@@ -6,7 +6,7 @@
 import 'package:enumerators/enumerators.dart' as e;
 import 'package:enumerators/combinators.dart' as c;
 import 'package:rational/rational.dart';
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 import 'src/common.dart';
 
 void testBools() {

--- a/test/combinators_test.dart
+++ b/test/combinators_test.dart
@@ -183,7 +183,7 @@ void testProductsOf() {
 void testPositiveRationalsArePositive() {
   c.positiveRationals
       .take(1000)
-      .forEach((r) => expect(r >= new Rational(0), isTrue));
+      .forEach((r) => expect(r >= new Rational(BigInt.from(0)), isTrue));
 }
 
 void testRationalsAreAllDifferent() {

--- a/test/enumerator_test.dart
+++ b/test/enumerator_test.dart
@@ -4,7 +4,7 @@
 // Author: Paul Brauner (polux@google.com)
 
 import 'package:enumerators/enumerators.dart';
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 import 'src/common.dart';
 
 void testPay() {

--- a/test/finite_test.dart
+++ b/test/finite_test.dart
@@ -4,7 +4,7 @@
 // Author: Paul Brauner (polux@google.com)
 
 import 'package:enumerators/enumerators.dart';
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 
 void testCardinalOfSum() {
   final empty = new Finite.empty();

--- a/test/finite_test.dart
+++ b/test/finite_test.dart
@@ -66,7 +66,7 @@ void testCardinalOfApply() {
 void testIndexEmpty() {
   final empty = new Finite.empty();
   for (int i = 0; i < 100; i++) {
-    expect(() => empty[i], throwsA(new isInstanceOf<RangeError>()));
+    expect(() => empty[i], throwsA(const TypeMatcher<RangeError>()));
   }
 }
 
@@ -74,7 +74,7 @@ void testIndexSingleton() {
   final foo = new Finite.singleton('foo');
   expect(foo[0], equals('foo'));
   for (int i = 1; i < 100; i++) {
-    expect(() => foo[i], throwsA(new isInstanceOf<RangeError>()));
+    expect(() => foo[i], throwsA(const TypeMatcher<RangeError>()));
   }
 }
 
@@ -91,7 +91,7 @@ void testIndexSum() {
     expect(sum[1], equals('bar'));
     expect(sum[2], equals('baz'));
     for (int i = 3; i < 100; i++) {
-      expect(() => sum[i], throwsA(new isInstanceOf<RangeError>()));
+      expect(() => sum[i], throwsA(const TypeMatcher<RangeError>()));
     }
   }
 }
@@ -111,7 +111,7 @@ void testIndexProd() {
   expect(prod[3].fst, equals('bar'));
   expect(prod[3].snd, equals('bar'));
   for (int i = 4; i < 100; i++) {
-    expect(() => prod[i], throwsA(new isInstanceOf<RangeError>()));
+    expect(() => prod[i], throwsA(const TypeMatcher<RangeError>()));
   }
 }
 
@@ -124,7 +124,7 @@ void testIndexMap() {
   expect(finDoubled[1], equals(4));
   expect(finDoubled[2], equals(6));
   for (int i = 3; i < 100; i++) {
-    expect(() => finDoubled[i], throwsA(new isInstanceOf<RangeError>()));
+    expect(() => finDoubled[i], throwsA(const TypeMatcher<RangeError>()));
   }
 }
 
@@ -138,7 +138,7 @@ void testIndexApply() {
   expect(applied[2], equals(3));
   expect(applied[3], equals(6));
   for (int i = 4; i < 100; i++) {
-    expect(() => applied[i], throwsA(new isInstanceOf<RangeError>()));
+    expect(() => applied[i], throwsA(const TypeMatcher<RangeError>()));
   }
 }
 
@@ -166,7 +166,7 @@ void testFirst() {
   final _42 = new Finite.singleton(42);
   final _43 = new Finite.singleton(43);
   expect(
-      () => new Finite.empty().first, throwsA(new isInstanceOf<StateError>()));
+      () => new Finite.empty().first, throwsA(const TypeMatcher<StateError>()));
   expect(_42.first, equals(42));
   expect((_42 + _43).first, equals(42));
   expect((_42 * _43).first, equals(new Pair(42, 43)));
@@ -177,7 +177,7 @@ void testLast() {
   final _42 = new Finite.singleton(42);
   final _43 = new Finite.singleton(43);
   expect(
-      () => new Finite.empty().last, throwsA(new isInstanceOf<StateError>()));
+      () => new Finite.empty().last, throwsA(const TypeMatcher<StateError>()));
   expect(_42.last, equals(42));
   expect((_42 + _43).last, equals(43));
   expect((_42 * _43).last, equals(new Pair(42, 43)));

--- a/test/src/common.dart
+++ b/test/src/common.dart
@@ -6,7 +6,7 @@
 library common;
 
 import 'package:enumerators/enumerators.dart';
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 
 Enumeration listToEnum(List<List> list) {
   return new Enumeration(


### PR DESCRIPTION
No static analysis errors, but I am getting the following error when running the test/run.sh script.

Not sure how to resolve it. I'll look at it later, but any feedback would be appreciated.


```
Unhandled exception:
type 'Enumeration<dynamic>' is not a subtype of type 'Enumeration<Nil>'
#0      new Enumeration.fix (package:enumerators/src/enumeration.dart:44:22)
#1      fix (package:enumerators/src/enumeration.dart:160:9)
#2      listsOf (package:enumerators/combinators.dart:67:23)
#3      stringsFrom (package:enumerators/combinators.dart:60:22)
#4      strings (package:enumerators/combinators.dart:47:37)
#5      strings (package:enumerators/combinators.dart:47:27)
#6      main (file:///Users/johnmcmahon/Workspace/GitHub/Stargator/enumerators/example/simple.dart:13:23)
#7      _startIsolate.<anonymous closure> (dart:isolate/runtime/libisolate_patch.dart:279:19)
#8      _RawReceivePortImpl._handleMessage (dart:isolate/runtime/libisolate_patch.dart:165:12)
```